### PR TITLE
リストボックス、テキストボックス、イメージボックスの変更

### DIFF
--- a/data/chip.json
+++ b/data/chip.json
@@ -1,8 +1,14 @@
 {
-    "0": {"name": "HP_UP", "equip_size": 1, "own_max": 10, "equip_max": 4},
-    "1": {"name": "CONTINUE", "equip_size": 3, "own_max": 2, "equip_max": 2},
-    "2": {"name": "SPEEDUP", "equip_size":1, "own_max": 8, "equip_max": 3},
-    "3": {"name": "SHORT_RELOAD", "equip_size": 2, "own_max": 8, "equip_max":3},
-    "4": {"name": "SHIELD", "equip_size":2, "own_max":4, "equip_max":1},
-    "5": {"name": "LONG_INVISIBLE", "equip_size": 2, "own_max": 4, "equip_max": 3}
+    "0": {"name": "HP_UP", "equip_size": 1, "own_max": 10, "equip_max": 4, 
+        "info":"最大HPが上がる\n枠:1\n装備上限:4"},
+    "1": {"name": "CONTINUE", "equip_size": 3, "own_max": 2, "equip_max": 2, 
+        "info":"コンティニューできる回数が増える\n枠:3\n装備上限:2"},
+    "2": {"name": "SPEEDUP", "equip_size":1, "own_max": 8, "equip_max": 3, 
+        "info":"スピードが上がる\n枠:1\n装備上限:3"},
+    "3": {"name": "SHORT_RELOAD", "equip_size": 2, "own_max": 8, "equip_max":3, 
+        "info":"リロード時間の短縮\n枠:2\n装備上限:3"},
+    "4": {"name": "SHIELD", "equip_size":2, "own_max":4, "equip_max":1, 
+        "info":"シールド状態で開始\n枠:2\n装備上限:1"},
+    "5": {"name": "LONG_INVISIBLE", "equip_size": 2, "own_max": 4, "equip_max": 3, 
+        "info":"無敵時間の延長\n枠:2\n装備上限:3"}
 }

--- a/equipment.py
+++ b/equipment.py
@@ -4,6 +4,7 @@ from define import *
 from listbox import ListBox
 from popupwindow import PopupWindow
 from image_box import ImageBox
+from textbox import TextBox
 
 class Equipment:
 
@@ -41,6 +42,8 @@ class Equipment:
         # 現在の装備状況を描画するイメージボックスの作成
         self.gun_image_box = ImageBox(screen, 700, 450, 90, 90, 3)
         self.chip_image_box = ImageBox(screen, 500, 450, 90, 90, 6)
+        
+        self.text_box = TextBox(screen, 550, 200, 550, 200, font_size=30)
         # 時間管理
         self.clock = pygame.time.Clock()
 
@@ -111,6 +114,18 @@ class Equipment:
             self.listbox.set_color(self.equipment, (105,105,255))
         # リストボックスの描画
         self.listbox.draw()
+
+        # 選択中の情報表示
+        if self.change_id == 1:
+            select = self.listbox.selected
+            if select == len(self.listbox)-1:
+                text = '装備している全てのチップを外す。'
+            elif select == len(self.listbox)-2:
+                text = '選択している装備済みのチップを外す。'
+            else:
+                text = self.chip_data[select]['info']
+            self.text_box.set_text(text)
+            self.text_box.draw()
 
         # 装備情報の描画
         if self.change_id == 0:

--- a/equipment.py
+++ b/equipment.py
@@ -8,33 +8,42 @@ from image_box import ImageBox
 class Equipment:
 
     def __init__(self, screen, data):
+        # データを保持
         self.gun_data = data["gun_data"]
         self.equipment = data["equip"]
         self.chip_data = data["chip_data"]
         self.chip = data["chip"]
+        # スクリーンの保持
         self.screen = screen
+        # 選択の初期値
         self.change_gun = 0             # 現在選択している装備場所
         self.change_chip = 0
+        self.change_id = 0
         self.back = False               # 一つ前の画面にもどるか
+        # 操作の表記
         self.screen_info = pygame.font.Font("font/freesansbold.ttf" ,70).render("Equip", True, (255,255,255))
         self.back_info = pygame.font.Font("font/ShipporiMincho-TTF-Regular.ttf" ,50).render("'Q' : 戻る", True, (255,255,255))
         self.change_info = pygame.font.Font("font/ShipporiMincho-TTF-Regular.ttf" ,50).render("'C' : 切り替え", True, (255,255,255))
-        self.change_id = 0
+        # リストボックスの作成
+        # Gun
         texts = [data["name"] for data in self.gun_data.values()]
         equip_listbox = ListBox(self.screen, 80, 200, 300, 250, texts, font_size=40, target=True,\
                                      title="Gun", title_size=60)
         equip_listbox.set_selectable([data["own"]==1 for data in self.gun_data.values()])
+        # Chip
         texts = [data['name'] for data in self.chip_data.values()]
         chip_listbox = ListBox(self.screen, 80, 200, 300, 250, texts, font_size=40, target=True,\
                                      title="Chip", title_size=60)
         chip_listbox += ['remove', 'remove ALL']
+        # 両方をリストに格納し、選択された方を描画
         self.listboxes = [equip_listbox, chip_listbox]
         self.listbox = self.listboxes[self.change_id]
+        # 現在の装備状況を描画するイメージボックスの作成
         self.gun_image_box = ImageBox(screen, 700, 450, 90, 90, 3)
         self.chip_image_box = ImageBox(screen, 500, 450, 90, 90, 6)
+        # 時間管理
         self.clock = pygame.time.Clock()
-        self.count = 0
-    
+
     def do(self):
         while True:
             self.clock.tick(30)
@@ -46,35 +55,49 @@ class Equipment:
 
     def process(self):
         # 内部処理
+        # チップのリストボックスで、選択の可否を設定
         select = [data["num"] > 0 for data in self.chip_data.values()] \
                     + [self.chip[self.change_chip]!=-1, self.chip!=[-1]*6]
         self.listboxes[1].set_selectable(select)
+        # 装備状況のターゲット選択
         self.gun_image_box.target = self.change_id==0
         self.chip_image_box.target = self.change_id==1
+
+        # ユーザー入力
         for event in pygame.event.get():
             select = self.listbox.process(event)
+
+            # リストボックスからアイテムが選択された
             if select != None:
                 if self.change_id == 0:
                     self.equip(select)
                 else:
                     self.set_chip(select)
+
+            # 閉じるボタンが選択された
             if event.type == QUIT:
+                # ゲーム終了のコードを返却する
                 return EXIT
+
+            # その他のキー入力が行われた
             if event.type == KEYDOWN:
+                # イメージボックスの入力処理
                 if self.change_id == 0:
                     self.gun_image_box.process(event.key)
                     self.change_gun = self.gun_image_box.select
                 else:
                     self.chip_image_box.process(event.key)
                     self.change_chip = self.chip_image_box.select
+                # Qキーが入力された
                 if event.key == K_q:
+                    # 一つ前の画面に戻る
                     return BACK
+                # Cキーが入力された
                 elif event.key == K_c:
                     self.change_id ^= 1
                     self.listbox = self.listboxes[self.change_id]
-        self.count = (self.count + 3) * (self.count+3 < 69)
         return CONTINUE
-        
+
     def draw(self):
         # 画面描画
         self.screen.fill((0,0,0))
@@ -82,16 +105,19 @@ class Equipment:
         self.screen.blit(self.back_info, [850, 20])
         self.screen.blit(self.change_info, [850, 90])
         
+        # リストボックスのカラー設定
         self.listbox.color_reset()
         if self.change_id == 0:
             self.listbox.set_color(self.equipment, (105,105,255))
+        # リストボックスの描画
         self.listbox.draw()
 
+        # 装備情報の描画
         if self.change_id == 0:
             self.draw_equip()
         else:
             self.draw_chip()
-
+        # 画面更新
         pygame.display.update()
 
     def draw_equip(self):
@@ -99,12 +125,15 @@ class Equipment:
         data_list = []
         id_list = []
         for data in self.equipment:
+            # 装備していない
             if data == -1:
                 data_list.append(None)
                 id_list.append(0)
+            # 画像がある
             elif data == 0:
                 data_list.append('img/gun_icon/'+str(data)+'/')
                 id_list.append(3)
+            # 画像がない
             else:
                 data_list.append(data)
                 id_list.append(0)
@@ -113,40 +142,44 @@ class Equipment:
                 
 
     def draw_chip(self):
+        # チップのIDを描画
         pygame.draw.rect(self.screen, (255,255,255), Rect(500, HEIGHT-150, 625, 100))
         self.chip_image_box.set_image([None if data==-1 else data for data in self.chip])
         self.chip_image_box.draw()
-        return
-        for i, data, in enumerate(self.chip):
-            color = (255,0,0) * (i == self.change_chip) or (0,)*3
-            pygame.draw.rect(self.screen, color, [530+95*i, HEIGHT-145, 90, 90], 2+(i==self.change_chip))
-            if data == -1:
-                continue
-            text = pygame.font.Font("font/freesansbold.ttf", 80).render(str(data), True, (0,0,0))
-            self.screen.blit(text, [555+95*i, HEIGHT-135])
 
+    def equip(self, select):
+        # 選択した銃を装備する。
+        if self.check(select):
+            equipment = self.equipment
+            equipment[self.change_gun] = select
 
     def check(self, select):
         # 装備変更確認
         for i, gun in enumerate(self.equipment):
+            # 選択した銃がすでに装備済み
             if gun == select:
+                # その場所が1番目(リストでの0番目)
                 if i == 0:
                     PopupWindow(self.screen, "1番目に装備されています。\n場所の変更ができません。", ["OK"]).loop()
                     return False
+                # その位置に選択した銃がすでに装備されている
                 if i == self.change_gun:
                     return False
+                # 変更可能な位置に装備している
                 while True:
                     if PopupWindow(self.screen, "すでに装備しています。\n場所を変更しますか？", \
                                    ["変更する", "変更しない"]).loop() == 0:
                         break
                     else:
                         return False
+                # 装備していた銃を外す
                 self.equipment[i] = -1
         return True
 
-    def _set_chip(self, select, size):
-        i = self.change_chip
+    def _set_chip(self, i, select, size):
+        # チップ装備処理
         self.chip_data[select]['num'] -= 1
+        # チップが要するサイズ分セット
         for j in range(size):
             self.chip[i+j] = select
         
@@ -156,21 +189,18 @@ class Equipment:
             chip = self.chip[j]
             if chip == -1:
                 continue
+            # 外したチップの情報
             data = self.chip_data[chip]
             chip_size = data['equip_size']
+            # 所持数を1増やす
             data['num'] += 1
+            # チップを装備から外す
             j -= chip_id_list[j]
             for k in range(j, j+chip_size):
                 self.chip[k] = -1
 
-    def equip(self, select):
-        # 選択した銃を装備する。
-        if self.check(select):
-            equipment = self.equipment
-            equipment[self.change_gun] = select
-
     def set_chip(self, select):
-        # チップの枠がサイズ何番目が保存されているのかを保持
+        # チップが要する枠のサイズごとに番号をつける(3枠のチップなら、[0,1,2]と番号をつける)
         chip_id_list = []
         i = 0
         while i < 6:
@@ -214,6 +244,7 @@ class Equipment:
         if count != size:
             if PopupWindow(self.screen, "必要な枠に装備されているチップをすべて外し、装備します。", ['OK', 'NO']).loop() == 1:
                 return
+        # 装備する場所にすでに装備されているチップを外す
         self._remove_chip(i, size, chip_id_list)
         # チップを装備する
-        self._set_chip(select, size)
+        self._set_chip(i, select, size)

--- a/equipment.py
+++ b/equipment.py
@@ -31,6 +31,7 @@ class Equipment:
         self.listboxes = [equip_listbox, chip_listbox]
         self.listbox = self.listboxes[self.change_id]
         self.gun_image_box = ImageBox(screen, 700, 450, 90, 90, 3)
+        self.chip_image_box = ImageBox(screen, 500, 450, 90, 90, 6)
         self.clock = pygame.time.Clock()
         self.count = 0
     
@@ -49,6 +50,7 @@ class Equipment:
                     + [self.chip[self.change_chip]!=-1, self.chip!=[-1]*6]
         self.listboxes[1].set_selectable(select)
         self.gun_image_box.target = self.change_id==0
+        self.chip_image_box.target = self.change_id==1
         for event in pygame.event.get():
             select = self.listbox.process(event)
             if select != None:
@@ -63,7 +65,8 @@ class Equipment:
                     self.gun_image_box.process(event.key)
                     self.change_gun = self.gun_image_box.select
                 else:
-                    self.chip_key(event.key)
+                    self.chip_image_box.process(event.key)
+                    self.change_chip = self.chip_image_box.select
                 if event.key == K_q:
                     return BACK
                 elif event.key == K_c:
@@ -71,14 +74,7 @@ class Equipment:
                     self.listbox = self.listboxes[self.change_id]
         self.count = (self.count + 3) * (self.count+3 < 69)
         return CONTINUE
-
-    def chip_key(self, key):
-        if key == K_RIGHT:
-            self.change_chip += 1
-        elif key == K_LEFT:
-            self.change_chip -= 1
-        self.change_chip = (self.change_chip + 6) % 6
-
+        
     def draw(self):
         # 画面描画
         self.screen.fill((0,0,0))
@@ -118,6 +114,9 @@ class Equipment:
 
     def draw_chip(self):
         pygame.draw.rect(self.screen, (255,255,255), Rect(500, HEIGHT-150, 625, 100))
+        self.chip_image_box.set_image([None if data==-1 else data for data in self.chip])
+        self.chip_image_box.draw()
+        return
         for i, data, in enumerate(self.chip):
             color = (255,0,0) * (i == self.change_chip) or (0,)*3
             pygame.draw.rect(self.screen, color, [530+95*i, HEIGHT-145, 90, 90], 2+(i==self.change_chip))

--- a/image_box.py
+++ b/image_box.py
@@ -44,7 +44,8 @@ class ImageBox:
                 text = pygame.font.Font("font/freesansbold.ttf", 80).render(str(data), True, (0,0,0))
                 rect = text.get_rect()
                 width, height = rect.right, rect.bottom
-                self.screen.blit(text, [x+self.image_width/2-width/2, y+self.image_height/2-height/2])
+                tx, ty = x+self.image_width/2-width/2, y+self.image_height/2-height*3/7
+                self.screen.blit(text, [tx, ty])
             # 枠の描画
             color = (0,)*3 * (self.select != i) or (255,0,0)
             size = 2 + (self.select==i) * 2

--- a/listbox.py
+++ b/listbox.py
@@ -27,7 +27,7 @@ class ListBox:
         self.font_size = font_size
         self.font = pygame.font.Font("font/freesansbold.ttf", font_size)
         self.title_size = title_size
-        self.title = pygame.font.Font("font/freesansbold.ttf", title_size).render(title, True, (255,255,255))
+        self.title = pygame.font.Font("font/freesansbold.ttf", title_size).render(title, True, (0,0,0))
         # 一度に描画する要素数
         self.draw_num = height // (font_size+10)
         # 要素の保持
@@ -43,8 +43,13 @@ class ListBox:
         # 枠線を描画
         pygame.draw.rect(self.screen, self.outline_color, self.rect, self.outline)
         # titleの描画
-        x, y = self.rect.left, self.rect.top - self.title_size
-        self.screen.blit(self.title, [x, y])
+        title_width = self.title.get_rect().right
+        if title_width != 0:
+            x, y = self.rect.left, self.rect.top - self.title_size
+            # 枠線の描画
+            pygame.draw.rect(self.screen, self.bg, Rect(x, y, title_width+6, self.title_size))
+            pygame.draw.rect(self.screen, self.outline_color, Rect(x, y, title_width+6, self.title_size), self.outline)
+            self.screen.blit(self.title, [x+3, y])
         if scroll:
             # スクロールバーの枠を描画
             rect = Rect(self.rect.right-18, self.rect.top+3, 15, self.rect.bottom-self.rect.top-6)

--- a/shooting.py
+++ b/shooting.py
@@ -138,7 +138,7 @@ class Main(pygame.sprite.Sprite):
                 pos += 1
             
     def _check_gun(self):
-        dic = json.load(open("data/gun.json", "r"))
+        dic = json.load(open("data/gun.json", "r", encoding='utf-8'))
         i = 0
         for name, data in dic.items():
             if i in self.data['gun_data']:
@@ -161,7 +161,7 @@ class Main(pygame.sprite.Sprite):
         if self.data['chip'] == []:
             self.data['chip'] = [-1 for _ in range(6)]
 
-        dic = json.load(open('data/chip.json', 'r'))
+        dic = json.load(open('data/chip.json', 'r', encoding='utf-8'))
         chip_data = self.data['chip_data']
         for str_id, value in dic.items():
             i = int(str_id)

--- a/textbox.py
+++ b/textbox.py
@@ -13,8 +13,8 @@ class TextBox:
         self.font_size = font_size
         self.outline_size = outline_size
         self.outline_color = outline_color
-        texts = self.separate_text(text)
-        self.texts = self.create_text(texts, full_font, half_font)
+        self.full_font, self.half_font = full_font, half_font
+        self.set_text(text)
         assert align[0] in ('left', 'center', 'right'), "選択できる横向きのalign属性('left', 'center', 'right')"
         assert align[1] in ('top', 'center', 'bottom'), "選択できる縦向きのalign属性('top', 'center', 'buttom')"
         self.align = align
@@ -48,8 +48,15 @@ class TextBox:
                 self.screen.blit(text, [x, y])
                 x += rect.right
 
+    def set_text(self, text):
+        texts = self.separate_text(text)
+        self.texts = self.create_text(texts)
+
+
     def separate_text(self, text):
         """入力したテキストを、全角部分と半角部分で分割し、順番はそのままにリストにする。"""
+        if text == '':
+            return text
         texts = []
         one_text = ''
         char_type = self.isfull_size(text[0])
@@ -66,7 +73,7 @@ class TextBox:
         texts.append([char_type, one_text])
         return texts
 
-    def create_text(self, texts, full_font, half_font):
+    def create_text(self, texts):
         """枠内に収まるサイズになるよう、全角、半角それぞれのテキストを画像化してリスト(二次元)に格納し、返却する。
         リストは各要素が一行に表示する文字列の画像で、要素の一つ一つが全角、半角ごとでリストにされている。"""
         # 枠内判定に用いるテキストの幅と枠の幅
@@ -77,7 +84,7 @@ class TextBox:
         # 全角半角ごとに分割したテキスト全てを描画形式に変換
         for char_type, text in texts:
             # フォント設定
-            font = pygame.font.Font(full_font*char_type or half_font, self.font_size)
+            font = pygame.font.Font(self.full_font*char_type or self.half_font, self.font_size)
             # 一文字ごとに描画テキストを作成
             for _char in text:
                 char = font.render(_char * (_char != '\n'), True, self.text_color)


### PR DESCRIPTION
- リストボックス
タイトルに背景を作成。

- テキストボックス
描画するテキストの作成を、クラス外からテキストを引数に指定するだけでできるようにした。

- イメージボックス
数字を描画するとき、少し上気味に表示されるのを修正。

---

1. 装備画面で、カーソルが指すチップの情報をテキストボックスで描画するようにした。
1. それに伴い、chip.jsonに'info'キーを追加。ここにテキストボックスで描画したい説明分を指定。